### PR TITLE
[Feat] Adding GitHub actions workflow to generate docker package on release

### DIFF
--- a/.github/workflows/publish-docker-on-release.yml
+++ b/.github/workflows/publish-docker-on-release.yml
@@ -1,0 +1,57 @@
+name: Publish Docker image on release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build-and-push:
+    name: Build and push Docker images
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Enforce lowercase variables for IMAGE_NAME
+        run: |
+          echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
+
+      - name: Set up QEMU (for multi-arch)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ !github.event.release.prerelease }}
+
+      - name: Build and push to GHCR
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/app/templates/auth/reset_password.html
+++ b/app/templates/auth/reset_password.html
@@ -17,6 +17,7 @@
     {% endwith %}
 
     <form method="POST">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
         <label for="new_password">New Password:</label><br>
         <input type="password" name="new_password" required><br><br>
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       TZ: America/New_York
       FLASK_ENV: production
       SECRET_KEY: ${SECRET_KEY}
-      DATABASE_URL: ${DATABASE_URL:-postgresql://brewuser:brewpass@db:5432/brewweb}  # Internal DB access
+      DATABASE_URL: ${DATABASE_URL:-postgresql://${POSTGRES_USER:-brewuser}:${POSTGRES_PASSWORD:-brewpass}@${POSTGRES_HOST:-db}:5432/${POSTGRES_DB:-brewweb}}
     depends_on:
       db:
         condition: service_healthy  # ✅ Wait until DB is healthy
@@ -25,13 +25,13 @@ services:
     ports:
       - "5544:5432"  # Expose externally on 5544
     environment:
-      POSTGRES_USER: brewuser
-      POSTGRES_PASSWORD: brewpass
-      POSTGRES_DB: brewweb
+      POSTGRES_USER: ${POSTGRES_USER:-brewuser}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-brewpass}
+      POSTGRES_DB: ${POSTGRES_DB:-brewweb}
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "brewuser", "-d", "postgres"]
+      test: ["CMD", "pg_isready", "-U", "${POSTGRES_USER:-brewuser}", "-d", "postgres"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -43,9 +43,9 @@ services:
     entrypoint: /bin/sh
     volumes:
       - ./backups:/backups
-    command: -c 'pg_dump -U brewuser -h db -d brewweb --no-owner --no-privileges --inserts -f /backups/manual_backup.sql'
+    command: -c 'pg_dump -U ${POSTGRES_USER:-brewuser} -h ${POSTGRES_HOST:-db} -d ${POSTGRES_DB:-brewweb} --no-owner --no-privileges --inserts -f /backups/manual_backup.sql'
     environment:
-      PGPASSWORD: brewpass
+      PGPASSWORD: ${POSTGRES_PASSWORD:-brewpass}
 
 volumes:
   pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   web:
-    build: .
+    image: ghcr.io/anndrox/brew-web:latest
     env_file: .env
     ports:
       - "4452:4452"  # External:Internal

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,11 +5,14 @@
 # 3) Seed default yeast data (best effort).
 # 4) Start Gunicorn on port 4452 with access/error logging.
 
-# Ensure psql commands can authenticate (can be overridden via PGPASSWORD env)
-export PGPASSWORD="${PGPASSWORD:-brewpass}"
+# Load environment variables with fallbacks to the original defaults
+DB_USER="${POSTGRES_USER:-brewuser}"
+DB_NAME="${POSTGRES_DB:-brewweb}"
+DB_HOST="${POSTGRES_HOST:-db}"
+export PGPASSWORD="${POSTGRES_PASSWORD:-brewpass}"
 
 echo "⏳ Waiting for database..."
-until psql -h db -U brewuser -d postgres -tAc "SELECT 1" >/dev/null 2>&1; do
+until psql -h "$DB_HOST" -U "$DB_USER" -d postgres -tAc "SELECT 1" >/dev/null 2>&1; do
   sleep 1
 done
 
@@ -21,9 +24,9 @@ if [ ! -f "/app/migrations/env.py" ]; then
 fi
 
 # Ensure database exists (handles fresh volumes)
-echo "🗄️ Ensuring database brewweb exists..."
-if ! psql -h db -U brewuser -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='brewweb';" | grep -q 1; then
-  createdb -h db -U brewuser -O brewuser -E UTF8 brewweb || true
+echo "🗄️ Ensuring database $DB_NAME exists..."
+if ! psql -h "$DB_HOST" -U "$DB_USER" -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='$DB_NAME';" | grep -q 1; then
+  createdb -h "$DB_HOST" -U "$DB_USER" -O "$DB_USER" -E UTF8 "$DB_NAME" || true
 fi
 
 flask db migrate -m "Auto migration" || true
@@ -31,7 +34,7 @@ flask db upgrade || true
 
 # Guard against missing new columns on restored backups (run after upgrade so table exists)
 echo "🔧 Ensuring app_settings.unit_preference column exists..."
-psql -h db -U brewuser -d brewweb -c "ALTER TABLE app_settings ADD COLUMN IF NOT EXISTS unit_preference VARCHAR(10) DEFAULT 'imperial';" || true
+psql -h "$DB_HOST" -U "$DB_USER" -d "$DB_NAME" -c "ALTER TABLE app_settings ADD COLUMN IF NOT EXISTS unit_preference VARCHAR(10) DEFAULT 'imperial';" || true
 
 echo "🌱 Seeding yeast types (if missing)..."
 flask seed-yeasts || true


### PR DESCRIPTION
 ### Addition of GitHub Actions Docker Publish & Deployment Fixes

It's great to see this project still being worked on! The repo itself looks in good shape. For a while, I've been running a [fork in my Forgejo instance](https://forgejo.jrhedman.app/Jrhedman/brew-web) for the packaging.

Since it seems like you're continuing to work on this when you have time, I thought I might assist with some QoL changes that might help benefit you, and make it easier for others who want to check out your project.

This PR introduces an automated GitHub Actions workflow to publish Docker images to GHCR on release, alongside a few necessary bug fixes and parameterization improvements to make the repository more robust for deployment.

#### 1. GitHub Actions - Automated Docker Publishing (.github/workflows/publish-docker-on-release.yml)

- Added a workflow that automatically builds and pushes the Docker image to the GitHub Container Registry (ghcr.io) whenever a new Release is published.
- Enforces lowercase repository names to prevent push errors to GHCR.
- Utilizes docker/metadata-action to automatically tag the image with the release version and latest.

> **Brief on using GHCR:**  
> Once you create a new release in GitHub, the workflow will run automatically. The first time the image is published, it will default to Private. You will need to navigate to the repository's "Packages" settings and change the visibility to Public if you want users to be able to pull.

#### 2. Switched docker-compose.yml to use new GHCR Image

- Removed `build: .` from docker-compose.yml and replaced it with `image: ghcr.io/anndrox/brew-web:latest`. 
- This allows end users to download the compose file and spin it up immediately without needing to pull down the full source code locally to build it.

#### 3. Parameterized Database Credentials

- The previous entrypoint.sh and docker-compose.yml had local development credentials (brewuser, brewpass, brewweb) hardcoded in multiple places. This caused (at least in my case) database connection failures if supplied a custom POSTGRES_USER in their .env file, because the psql health checks and pg_dump commands would ignore the .
env and blindly try to authenticate as brewuser.
- Fix: Parameterized all hardcoded values in entrypoint.sh and docker-compose.yml to use standard environment variables. **NOTE:** _They still fall back to brewuser by default, so this change is backwards compatible and will not break any existing local development setups._

#### 4. Corrected CSRF Token Bugfix on Password Reset

- If a user triggers the force_reset.flag recovery flow, they are presented with a raw HTML form to reset the admin password.
- Because Flask-WTF CSRF protection is enabled globally, submitting this raw HTML form threw a 400 Bad Request: The CSRF token is missing error, trapping the user in a recovery loop.
- Fix: Added the missing `<input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>` to `app/templates/auth/reset_password.html` to allow the form to submit successfully.

I caught this one because I still had [the old logic where the reset.flag was expected](https://github.com/anndrox/brew-web/commit/6734dc002f03aae9c7c073f725b053bf5dd79ff1#diff-0f066672bb2866831c8a0b61c48c718390334d798b547ee7519b20977c2b8653L22-R26) (_This is why you don't update blindly self!!_)

Thanks for such a great project! Looking forward to where it goes!