### PR TITLE
Constrain automated runtime upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,14 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    ignore:
+      - dependency-name: python
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
+      - dependency-name: postgres
+        update-types:
+          - version-update:semver-major
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
Keeps Dependabot digest and compatible maintenance updates while preventing automatic Python minor/runtime jumps and PostgreSQL major-version jumps. Runtime upgrades remain deliberate, tested changes.